### PR TITLE
added filter to remove zero count data from all pathogen view handlers

### DIFF
--- a/configsets/vb_popbio/conf/configoverlay.json
+++ b/configsets/vb_popbio/conf/configoverlay.json
@@ -245,7 +245,7 @@
         "wt": "json",
         "json.nl": "map",
         "rows": 0,
-        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\",\"${bbox}\"],\"facet\":{\"geo\":{\"type\":\"terms\",\"field\":\"${geo:geohash_2}\",\"limit\":-1,\"mincount\":1,\"sort\":{\"count\":\"desc\"},\"facet\":{\"ltAvg\":\"avg(geo_coords_ll_0_coordinate)\",\"ltMin\":\"min(geo_coords_ll_0_coordinate)\",\"ltMax\":\"max(geo_coords_ll_0_coordinate)\",\"lnAvg\":\"avg(geo_coords_ll_1_coordinate)\",\"lnMin\":\"min(geo_coords_ll_1_coordinate)\",\"lnMax\":\"max(geo_coords_ll_1_coordinate)\",atomicCount:\"unique(${geomax:geohash_7})\",\"term\":{\"type\":\"terms\",\"field\":\"${term:infection_status_s}\",\"limit\": -1,\"mincount\":1}}}}}"
+        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\",\"${bbox}\",\"-sample_size_i:0\"],\"facet\":{\"geo\":{\"type\":\"terms\",\"field\":\"${geo:geohash_2}\",\"limit\":-1,\"mincount\":1,\"sort\":{\"count\":\"desc\"},\"facet\":{\"ltAvg\":\"avg(geo_coords_ll_0_coordinate)\",\"ltMin\":\"min(geo_coords_ll_0_coordinate)\",\"ltMax\":\"max(geo_coords_ll_0_coordinate)\",\"lnAvg\":\"avg(geo_coords_ll_1_coordinate)\",\"lnMin\":\"min(geo_coords_ll_1_coordinate)\",\"lnMax\":\"max(geo_coords_ll_1_coordinate)\",atomicCount:\"unique(${geomax:geohash_7})\",\"term\":{\"type\":\"terms\",\"field\":\"${term:infection_status_s}\",\"limit\": -1,\"mincount\":1}}}}}"
       }
     },
     "/pathPalette": {
@@ -259,7 +259,7 @@
         "wt": "json",
         "json.nl": "map",
         "rows": 0,
-        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\"],\"facet\":{\"geo\":{\"type\":\"terms\",\"field\":\"${geo:geohash_2}\",\"limit\":2000,\"mincount\":1,\"sort\":{\"count\":\"desc\"},\"facet\":{\"terms\":{\"type\":\"terms\",\"field\":\"${term:species_category}\",\"limit\":2000,\"mincount\":1,\"sort\":{\"count\":\"desc\"}}}}}}"
+        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\",\"-sample_size_i:0\"],\"facet\":{\"geo\":{\"type\":\"terms\",\"field\":\"${geo:geohash_2}\",\"limit\":2000,\"mincount\":1,\"sort\":{\"count\":\"desc\"},\"facet\":{\"terms\":{\"type\":\"terms\",\"field\":\"${term:species_category}\",\"limit\":2000,\"mincount\":1,\"sort\":{\"count\":\"desc\"}}}}}}"
       }
     },
     "/pathGraphdata": {
@@ -275,7 +275,7 @@
         "rows": 0,
         "facet": "true",
         //DKDK VB-8390 infection_status_s:* to (present OR equivocal)
-        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\",\"${date_resolution}:*\"],\"facet\":{\"term\":{\"type\":\"terms\",\"limit\":${termLimit:-1},\"field\":\"${term:species_category}\",\"facet\":{\"collection_dates\":{\"type\":\"terms\",\"limit\":2000,\"sort\":\"index\",\"field\":\"${date_resolution:collection_day_s}\",\"facet\":{\"infected\":{\"type\":\"query\",\"q\":\"infection_status_s:(present OR equivocal)\",\"facet\":{\"pathogen\":{\"type\":\"terms\",\"field\":\"infection_source_s\"}}}}}}}}}"
+        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\",\"${date_resolution}:*\",\"-sample_size_i:0\"],\"facet\":{\"term\":{\"type\":\"terms\",\"limit\":${termLimit:-1},\"field\":\"${term:species_category}\",\"facet\":{\"collection_dates\":{\"type\":\"terms\",\"limit\":2000,\"sort\":\"index\",\"field\":\"${date_resolution:collection_day_s}\",\"facet\":{\"infected\":{\"type\":\"query\",\"q\":\"infection_status_s:(present OR equivocal)\",\"facet\":{\"pathogen\":{\"type\":\"terms\",\"field\":\"infection_source_s\"}}}}}}}}}"
       }
     },
     "/pathMarkerYearRange": {
@@ -295,7 +295,7 @@
         "facet.limit": "-1",
         "facet.mincount": "1",
         "facet": "true",
-        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\"],\"facet\":{\"term\":{\"type\":\"terms\",\"limit\":-1,\"field\":\"${term:species_category}\"}}}",
+        "json": "{\"filter\":[\"bundle:pop_sample_phenotype\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"has_geodata:true\",\"-sample_size_i:0\"],\"facet\":{\"term\":{\"type\":\"terms\",\"limit\":-1,\"field\":\"${term:species_category}\"}}}",
         "json.facet": "{\"collection_resolution\":{\"terms\":\"collection_date_resolution_s\"}}"
       }
     },
@@ -311,7 +311,7 @@
         "distrib": "false"
       },
       "appends": {
-        "json": "{filter:[\"bundle:pop_sample_phenotype\",\"has_geodata:true\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\"]}"
+        "json": "{filter:[\"bundle:pop_sample_phenotype\",\"has_geodata:true\",\"phenotype_type_s:\\\"infection status\\\"\",\"infection_status_s:*\",\"-sample_size_i:0\"]}"
       },
       "components": [ "query" ]
     },


### PR DESCRIPTION
This is a change we will need to merge into master (unless we run the container off this branch?)

I have added the "no zero samples" filter to the pathGeoclust handler even though this is not strictly necessary because the MapVEu client is already adding it as a standalone parameter (I think due to DK's recent performance-related work).

When we've fixed the data we could roll this back (though that won't be essential).

In the refactored map, adjustments to Solr queries will all be done in the REST data API implementation, and not in the Solr config, so that will make it easier to develop (without restarting Solr containers).