### PR TITLE
Purge APT cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ COPY configsets/ /opt/solr/server/solr/configsets/
 
 USER root
 # we want jq for api parsing
-RUN apt update && apt install -y jq openssh-client
+RUN apt update && apt install -y jq openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 # create solr's home dir so ssh doesn't complain
 RUN mkdir /home/solr && chown solr /home/solr
 COPY crepo_files/crepo /usr/local/bin/crepo


### PR DESCRIPTION
This minor improvement will purge the APT cache after package installation reducing the image's overall size and the size of this particular layer.