### PR TITLE
Add docvalues to all `*_category` fields

### DIFF
--- a/configsets/vb_popbio/conf/schema_extra_fields.xml
+++ b/configsets/vb_popbio/conf/schema_extra_fields.xml
@@ -50,9 +50,9 @@
     <copyField source="species" dest="species_category"/>
 
     <!-- These fields are non-tokenized copies to allow pivoting used in summarizing the markers -->
-    <field name="collection_protocols_category" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="collection_protocols_category" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <copyField source="collection_protocols" dest="collection_protocols_category"/>
-    <field name="protocols_category" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="protocols_category" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <copyField source="protocols" dest="protocols_category"/>
 
 
@@ -185,7 +185,7 @@
     <field name="projects" type="text_ws_na" indexed="true" stored="true" multiValued="true"/>
     <copyField source="projects" dest="text"/>
 
-    <field name="projects_category" type="string_na" indexed="true" stored="true" multiValued="true"/>
+    <field name="projects_category" type="string_na" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <copyField source="projects" dest="projects_category"/>
 
     <field name="insecticides_cvterms" type="text_ws_finer" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
https://redmine.apidb.org/issues/50338

This will hopefully resolve the out of memory error while uninverting the `collection_protocols_category` field (I assume it will no longer need uninverting).

Originally reported [here](https://epvb.slack.com/archives/CR699HKS9/p1673621283802409). Drew then DM'ed me about the OOM error:

```
2023-01-27 16:59:17.425 INFO (qtp434610528-3862) [  x:vb_popbio] o.a.s.c.S.Request [vb_popbio] webapp=/solr path=/smplPalette params={geo=geohash_2&q=*:*&json.wrf=jQuery22200003931507885313046_1674838745894&callback=?&term=collection_protocols_category&_=1674838745897} hits=1785787 status=500 QTime=307
2023-01-27 16:59:17.425 ERROR (qtp434610528-3862) [  x:vb_popbio] o.a.s.s.HttpSolrCall null:org.apache.solr.common.SolrException: Exception occurs during uninverting collection_protocols_category
    at org.apache.solr.search.facet.UnInvertedField.rethrowAsSolrException(UnInvertedField.java:625)
    at org.apache.solr.search.facet.UnInvertedField.getUnInvertedField(UnInvertedField.java:615)
    at org.apache.solr.search.facet.FacetFieldProcessorByArrayUIF.findStartAndEndOrds(FacetFieldProcessorByArrayUIF.java:43)
    at org.apache.solr.search.facet.FacetFieldProcessorByArray.calcFacets(FacetFieldProcessorByArray.java:84)
    at org.apache.solr.search.facet.FacetFieldProcessorByArray.process(FacetFieldProcessorByArray.java:62)
[snipped]
Caused by: java.lang.OutOfMemoryError: Java heap space
```
